### PR TITLE
Develop

### DIFF
--- a/processes/cistarget.nf
+++ b/processes/cistarget.nf
@@ -37,7 +37,7 @@ process CISTARGET {
         pyscenic ctx \
             ${f} \
             ${featherDB} \
-            ${processParams.containsKey('allModules') && processParams.allModules ? '--all_modules': ''} \
+            ${processParams.containsKey('all_modules') && processParams.all_modules ? '--all_modules': ''} \
             --annotations_fname ${annotation} \
             --expression_mtx_fname ${filteredLoom} \
             --cell_id_attribute ${toolParams.cell_id_attribute} \

--- a/processes/cistarget.nf
+++ b/processes/cistarget.nf
@@ -37,6 +37,7 @@ process CISTARGET {
         pyscenic ctx \
             ${f} \
             ${featherDB} \
+            ${processParams.containsKey('allModules') && processParams.allModules ? '--all_modules': ''} \
             --annotations_fname ${annotation} \
             --expression_mtx_fname ${filteredLoom} \
             --cell_id_attribute ${toolParams.cell_id_attribute} \

--- a/processes/reports.nf
+++ b/processes/reports.nf
@@ -13,7 +13,7 @@ process GENERATE_REPORT {
 
 	container toolParams.container
 	publishDir "${toolParams.scenicoutdir}/${sampleId}/notebooks", mode: 'link', overwrite: true
-    label 'compute_resources__mem'
+    label 'compute_resources__report'
 
 	input:
 		file ipynb
@@ -36,7 +36,7 @@ process REPORT_TO_HTML {
 
 	container toolParams.container
 	publishDir "${toolParams.scenicoutdir}/${sampleId}/notebooks", mode: 'link', overwrite: true
-    label 'compute_resources__minimal'
+    label 'compute_resources__report'
 
 	input:
 		tuple val(sampleId), path(ipynb)

--- a/scenic.config
+++ b/scenic.config
@@ -27,7 +27,6 @@ params {
                 /*
                 --no_pruning
                 --chunk_size
-                --all_modules
                 --transpose
                 */
 
@@ -44,6 +43,7 @@ params {
                 top_n_targets = 50
                 top_n_regulators = '5,10,50'
                 min_genes = 20
+                all_modules = false
                 // expression_mtx_fname = '' // uses params.scenic.filteredLoom
             }
             aucell {


### PR DESCRIPTION
- Allow to use --all_modules argument when running the cisTarget step 4fb490a
- Label all process that generate reports with 'compute_resources__report' 57f9a78